### PR TITLE
Lisätty Corona Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ HS on käyttänyt ja käyttää dataa ainakin näissä grafiikoissa:
 
 (Tee pull request jos haluat omasi tänne.)
 
+
+[Corona Monitor](https://github.com/Matsuuu/finnish-corona-statistics) ([Matsuuu](https://github.com/Matsuuu))
+
 # Huomautus
 
 Tämä data on peräisin julkisista lähteistä. HS pyrkii kasaamaan sen mahdollisimman paikkansa pitävänä. Emme takaa, että päivitämme dataa jatkuvasti ja saatamme lopettaa datan päivittämisen ennalta ilmoittamatta, esimerkiksi tartuntatilanteen tai julkisten lähteiden muuttuessa. Saatamme myös muuttaa datarakennetta tai osoitteita ennalta ilmoittamatta.


### PR DESCRIPTION
Lisätty visualisointi-sivustoni, jossa visualisoin kevyin graafein Koronavirustapausten lukumääriä.

Projekti on vielä kevyt, mutta laajenee ajan kanssa