### PR TITLE
Add Hoitsubotti as new user of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ HS on käyttänyt ja käyttää dataa ainakin näissä grafiikoissa:
 
 [State of corona in Finland](https://coronainfinland.herokuapp.com/) ([pauliinasol](https://github.com/pauliinasol/corona-in-finland/))
 
+[Hoitsubotti - telegram-botti](https://t.me/Hoitsubot) ([Karvaporsas](https://github.com/Karvaporsas/hoitsubotti))
+
 # Huomautus
 
 Tämä data on peräisin julkisista lähteistä. HS pyrkii kasaamaan sen mahdollisimman paikkansa pitävänä. Emme takaa, että päivitämme dataa jatkuvasti ja saatamme lopettaa datan päivittämisen ennalta ilmoittamatta, esimerkiksi tartuntatilanteen tai julkisten lähteiden muuttuessa. Saatamme myös muuttaa datarakennetta tai osoitteita ennalta ilmoittamatta.


### PR DESCRIPTION
This is a new Telegram bot that displays corona virus data and sends updates of new cases to users